### PR TITLE
Remove gtk-vnv.yml from main.yml

### DIFF
--- a/roles/vnv/tasks/main.yml
+++ b/roles/vnv/tasks/main.yml
@@ -35,10 +35,10 @@
         (component == 'all')
 
 # deploy tng-gtk-vnv
-- import_tasks: gtk-vnv.yml
-  when: (component == 'gatekeeper') or
-        (component == 'gtk-vnv') or
-        (component == 'all')
+#- import_tasks: gtk-vnv.yml
+#  when: (component == 'gatekeeper') or
+#        (component == 'gtk-vnv') or
+#        (component == 'all')
 
 # deploy tng-api-gtw
 - import_tasks: api-gtw.yml


### PR DESCRIPTION
We're (temporarily) removing the gtk-vnv.yml from main.yml